### PR TITLE
add support for handoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,11 @@
     },
     "mac": {
       "category": "public.app-category.social-networking",
+      "extendInfo": {
+        "NSUserActivityTypes": [
+          "org.matrix.room"
+        ]
+      },
       "darkModeSupport": true
     },
     "win": {

--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -1037,6 +1037,20 @@ app.on('second-instance', (ev, commandLine, workingDirectory) => {
     }
 });
 
+app.on('continue-activity', (ev, type, userInfo) => {
+    if (type == "org.matrix.room" && userInfo["id"]) {
+        ev.preventDefault();
+
+        mainWindow.loadURL('vector://vector/webapp/#/room/'.concat(userInfo["id"]));
+
+        if (mainWindow) {
+            if (!mainWindow.isVisible()) mainWindow.show();
+            if (mainWindow.isMinimized()) mainWindow.restore();
+            mainWindow.focus();
+        }
+    }
+});
+
 // Set the App User Model ID to match what the squirrel
 // installer uses for the shortcut icon.
 // This makes notifications work on windows 8.1 (and is


### PR DESCRIPTION
This adds support for [Handoff](https://developer.apple.com/documentation/foundation/task_management/implementing_handoff_in_your_app). This only works when both client (iOS and schildichat) are signed by the same developer, and only if the client implements this feature. Currently the only client to implement this is [Nio in my fork](https://github.com/kloenk/nio/tree/seperate-oses). I plan to implement this in element-ios, but currently my setup does not compile. 