### PR TITLE
Support schildichat protocol

### DIFF
--- a/overlay-package.json
+++ b/overlay-package.json
@@ -52,6 +52,20 @@
       "entitlements": "build/entitlements.mas.plist",
       "provisioningProfile": "build/schildi_dev.provisionprofile",
       "hardenedRuntime": false
-    }
+    },
+    "protocols": [
+      {
+        "name": "element",
+        "schemes": [
+          "element"
+        ]
+      },
+      {
+        "name": "schildichat",
+        "schemes": [
+          "schildichat"
+        ]
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -147,6 +147,12 @@
         "schemes": [
           "element"
         ]
+      },
+      {
+        "name": "schildichat",
+        "schemes": [
+          "schildichat"
+        ]
       }
     ],
     "deb": {


### PR DESCRIPTION
Currently, the desktop app supports element:// but there is no specific
protocol for schildichat.  This change adds support for schildichat:// in
addition to element://

Tested on crapos but not linux or windows
schildichat://vector/webapp/#/room%2F%23web%3Aschildi.chat

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->